### PR TITLE
Fix grafana dashboard for big number of jobs

### DIFF
--- a/grafana-bareos.json
+++ b/grafana-bareos.json
@@ -2117,38 +2117,11 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": false,
-          "text": [
-            "BackupCatalog",
-            "argon1",
-            "backup-dc-srv01-fd",
-            "backup-gm-fd",
-            "backup-mail-fd",
-            "backup-rd-srv01-fd",
-            "backup-vkasse-fd",
-            "backup-winad-fd",
-            "desk1",
-            "kmaster",
-            "mailrelay",
-            "rothsee-new",
-            "vereinsheim"
-          ],
-          "value": [
-            "BackupCatalog",
-            "argon1",
-            "backup-dc-srv01-fd",
-            "backup-gm-fd",
-            "backup-mail-fd",
-            "backup-rd-srv01-fd",
-            "backup-vkasse-fd",
-            "backup-winad-fd",
-            "desk1",
-            "kmaster",
-            "mailrelay",
-            "rothsee-new",
-            "vereinsheim"
-          ]
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
Value "All" adds all job names to a request to Prometheus and if the number of jobs is big enough, this leads to error because of too long request URL.